### PR TITLE
fix GitHub::Meta plugin on perl 5.8

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHub/Meta.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub/Meta.pm
@@ -158,7 +158,8 @@ sub metadata {
 		$wiki = "$html_url/wiki";
 	}
 
-	my $meta -> {'resources'} = {
+	my $meta;
+	$meta -> {'resources'} = {
 		'repository' => {
 			'web'  => $html_url,
 			'url'  => $git_url,


### PR DESCRIPTION
Due to autovivification bug, `my $foo->{bar} = 123` is not working on perl 5.8.

(I couldn't use any other modules since token authentification was removed on June 1st., btw)
