### PR TITLE
Syntax error when used on Travis-ci

### DIFF
--- a/lib/Dist/Zilla/App/Command/gh.pm
+++ b/lib/Dist/Zilla/App/Command/gh.pm
@@ -1,6 +1,6 @@
 package Dist::Zilla::App::Command::gh;
 
-use v5.10;
+use feature 'switch';
 
 use strict;
 use warnings;


### PR DESCRIPTION
Hi - I use this Dist::Zilla plugin on one of my modules.  For some reason, travis-ci.org is complaining about a syntax error in your module (under perl v5.10.1): https://travis-ci.org/brianphillips/WebService-Shutterstock/jobs/3759981

Here's the error:

`syntax error at /home/travis/perl5/perlbrew/perls/5.10/lib/site_perl/5.10.1/Dist/Zilla/App/Command/gh.pm line 43, near ") {"`

I checked cpantesters and there are no failures for your module under perl v5.10.1 so I'm not sure what's going on.  Any ideas?
