### PR TITLE
fix uninitialized warning

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHub/Create.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub/Create.pm
@@ -146,7 +146,8 @@ sub _current_branch {
 
 	open my $pipe, '-|', "git", "--git-dir=$git_dir", "rev-parse", "--abbrev-ref", "--symbolic-full-name", "HEAD";
 
-	chomp(my $branch = <$pipe>);
+	my $branch = <$pipe>;
+	chomp($branch) if defined $branch;
 
 	close $pipe;
 


### PR DESCRIPTION
Sorry to bother you again, but as I was laying in bed last night I realized that I left a nasty uninitialized warning in my code.

Now, since STDERR is closed, this warning will usually not go anywhere, but I think it's best to fix it anyway.

Speaking of duping STDERR, do you know if the trick I used to save/close/restore it will work on Win32? I'm guessing the caution we're using with external processes is for compatibility reasons.
