### PR TITLE
wrap $git->rev_parse in a try {} block

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHub/Create.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub/Create.pm
@@ -130,9 +130,9 @@ sub after_mint {
 		$self -> log("Setting GitHub remote '".$self -> remote."'");
 		$git -> remote("add", $self -> remote, $repo -> {'ssh_url'});
 
-		my ($branch) = $git -> rev_parse(
+		my ($branch) = try { $git -> rev_parse(
 			{ abbrev_ref => 1, symbolic_full_name => 1 }, 'HEAD'
-		);
+		) };
 
 		if ($branch) {
 			try {


### PR DESCRIPTION
When there are no commits, $git->rev_parse will print a bunch of crap to
STDERR, wrapping it in a try block silences it.

E.g.:

rkitover@macmini ~ % cd /tmp
rkitover@macmini /tmp % mkdir foo
rkitover@macmini /tmp % cd foo
rkitover@macmini /tmp/foo % git init
Initialized empty Git repository in /private/tmp/foo/.git/
rkitover@macmini /tmp/foo % touch README
rkitover@macmini /tmp/foo %
rkitover@macmini /tmp/foo % ls
README
rkitover@macmini /tmp/foo % perl -MGit::Wrapper -le 'my $git = Git::Wrapper->new("."); print $git->rev_parse({ symbolic_full_name => 1, abbrev_ref => 1 }, "HEAD")'
fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
rkitover@macmini /tmp/foo % perl -MGit::Wrapper -MTry::Tiny -le 'my $git = Git::Wrapper->new("."); try { print $git->rev_parse({ symbolic_full_name => 1, abbrev_ref => 1 }, "HEAD") };'
rkitover@macmini /tmp/foo %
