### PR TITLE
Change phase for [Github::Update] from Releaser to AfterRelease

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHub/Update.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub/Update.pm
@@ -8,7 +8,7 @@ use Moose;
 
 extends 'Dist::Zilla::Plugin::GitHub';
 
-with 'Dist::Zilla::Role::Releaser';
+with 'Dist::Zilla::Role::AfterRelease';
 
 has 'cpan' => (
 	is	=> 'ro',
@@ -71,7 +71,7 @@ when C<dzil release> is run.
 
 =cut
 
-sub release {
+sub after_release {
 	my $self	= shift;
 	my ($opts)	= @_;
 	my $dist_name	= $self -> zilla -> name;


### PR DESCRIPTION
Strictly speaking, updating github doesn't constitute performing a release - it is just something that is done at release time, like tagging, pushing, etc.
