### PR TITLE
Net::SSLeay is required by HTTP::Tiny

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -9,6 +9,7 @@ pod_coverage = 0
 
 [Prereqs]
 IO::Socket::SSL = 1.56
+Net::SSLeay = 1.49
 
 [PruneFiles]
 filename = README.pod

--- a/lib/Dist/Zilla/Plugin/GitHub.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub.pm
@@ -145,6 +145,12 @@ sub _check_response {
 
 		return $json_text;
 	} catch {
+		if ($response and !$response -> {'success'} and $response -> {'status'} eq '599') {
+		    #possibly HTTP::Tiny error
+			$self -> log("Err: ", $response -> {'content'});
+			return;
+		}
+
 		$self -> log("Err: Can't connect to GitHub");
 
 		return;


### PR DESCRIPTION
Also print messages from HTTP::Tiny. Should fix issue #31.
