### PR TITLE
added JSON 2.90 as a dependency. 

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -10,6 +10,7 @@ pod_coverage = 0
 [Prereqs]
 IO::Socket::SSL = 1.56
 Net::SSLeay = 1.49
+JSON = 2.90
 
 [PruneFiles]
 filename = README.pod


### PR DESCRIPTION
Previous versions cannot handle JSON::XS 3.0+ b/c of changes in the way bools are handled (see Caution section in JSON README)
