### PR TITLE
Make having a token a non-fatal error, and swizzle a token w/o password into the password slot

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHub.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub.pm
@@ -84,12 +84,17 @@ sub _get_credentials {
 		} else {
 			$token = `git config github.token`;    chomp $token;
 			$pass  = `git config github.password`; chomp $pass;
+
+			# modern "tokens" can be used as passwords with basic auth, so...
+			# see https://help.github.com/articles/creating-an-access-token-for-command-line-use
+			$pass ||= $token
+				if $token;
 		}
 
-		if ($token) {
-			$self -> log("Err: Login with GitHub token is deprecated");
-			return (undef, undef);
-		} elsif (!$pass) {
+		$self -> log("Err: Login with GitHub token is deprecated")
+			if $token && !$pass;
+
+		if (!$pass) {
 			require Term::ReadKey;
 
 			Term::ReadKey::ReadMode('noecho');


### PR DESCRIPTION
Modern "tokens" can be used as passwords for basic auth; see 
https://help.github.com/articles/creating-an-access-token-for-command-line-use

As people may have a perfectly legitimate reason for having github.token set 
in their git config, this fatal error becomes a passthrough warning (when
.token but not .password is set).
