### PR TITLE
switch from JSON.pm to JSON::MaybeXS

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHub.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub.pm
@@ -3,7 +3,7 @@ package Dist::Zilla::Plugin::GitHub;
 use strict;
 use warnings;
 
-use JSON;
+use JSON::MaybeXS;
 use Moose;
 use Try::Tiny;
 use HTTP::Tiny;
@@ -145,7 +145,7 @@ sub _check_response {
 	my ($self, $response) = @_;
 
 	try {
-		my $json_text = from_json $response -> {'content'};
+		my $json_text = decode_json($response) -> {'content'};
 
 		if (!$response -> {'success'}) {
 			return 'redo' if (($response -> {'status'} eq '401') and

--- a/lib/Dist/Zilla/Plugin/GitHub/Create.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub/Create.pm
@@ -3,7 +3,7 @@ package Dist::Zilla::Plugin::GitHub::Create;
 use strict;
 use warnings;
 
-use JSON;
+use JSON::MaybeXS;
 use Moose;
 use Try::Tiny;
 use Git::Wrapper;
@@ -153,7 +153,7 @@ sub after_mint {
 		$self -> log([ "Using two-factor authentication" ]);
 	}
 
-	$content = to_json $params;
+	$content = encode_json($params);
 
 	my $response = $http -> request('POST', $url, {
 		content => $content,

--- a/lib/Dist/Zilla/Plugin/GitHub/Meta.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub/Meta.pm
@@ -3,7 +3,7 @@ package Dist::Zilla::Plugin::GitHub::Meta;
 use strict;
 use warnings;
 
-use JSON;
+use JSON::MaybeXS;
 use Moose;
 
 extends 'Dist::Zilla::Plugin::GitHub';
@@ -133,7 +133,7 @@ sub metadata {
 
 	$self -> log("Using offline repository information") if $offline;
 
-	if (!$offline && $repo->{'fork'} == JSON::true() && $self->fork == 1) {
+	if (!$offline && $repo->{'fork'} == JSON->true() && $self->fork == 1) {
 		my $parent   = $repo -> {'parent'} -> {'full_name'};
 		my $url      = $self -> api.'/repos/'.$parent;
 		my $response = $http -> request('GET', $url);
@@ -154,11 +154,11 @@ sub metadata {
 
 	$homepage = $offline ? undef : $repo -> {'homepage'};
 
-	if (!$offline && $repo -> {'has_issues'} == JSON::true()) {
+	if (!$offline && $repo -> {'has_issues'} == JSON->true()) {
 		$bugtracker = "$html_url/issues";
 	}
 
-	if (!$offline && $repo -> {'has_wiki'} == JSON::true()) {
+	if (!$offline && $repo -> {'has_wiki'} == JSON->true()) {
 		$wiki = "$html_url/wiki";
 	}
 

--- a/lib/Dist/Zilla/Plugin/GitHub/Update.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub/Update.pm
@@ -3,7 +3,7 @@ package Dist::Zilla::Plugin::GitHub::Update;
 use strict;
 use warnings;
 
-use JSON;
+use JSON::MaybeXS;
 use Moose;
 
 extends 'Dist::Zilla::Plugin::GitHub';
@@ -129,7 +129,7 @@ sub after_release {
 		$self -> log([ "Using two-factor authentication" ]);
 	}
 
-	$content = to_json $params;
+	$content = encode_json($params);
 
 	my $response = $http -> request('PATCH', $url, {
 		content => $content,


### PR DESCRIPTION
This changes the JSON backend from JSON.pm (which only uses JSON::XS) to JSON::MaybeXS, which selects between backends depending on what is already installed and loaded.
