### PR TITLE
Modify _get_repo_name to use C locale when runing git

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHub.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub.pm
@@ -130,7 +130,7 @@ sub _get_repo_name {
         ($url) = map /Fetch URL: (.*)/,
             $git->remote('show', '-n', $self->remote);
     }
- 
+
     $url =~ /github\.com.*?[:\/](.*)\.git$/;
     $repo = $1 unless $repo and not $1;
 

--- a/lib/Dist/Zilla/Plugin/GitHub.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub.pm
@@ -124,9 +124,13 @@ sub _get_repo_name {
 
     $repo = $self->repo if $self->repo;
 
-    my ($url) = map /Fetch URL: (.*)/,
-        $git->remote('show', '-n', $self->remote);
-
+    my $url;
+    {
+        local $ENV{LANG}='C';
+        ($url) = map /Fetch URL: (.*)/,
+            $git->remote('show', '-n', $self->remote);
+    }
+ 
     $url =~ /github\.com.*?[:\/](.*)\.git$/;
     $repo = $1 unless $repo and not $1;
 


### PR DESCRIPTION
The outoput of git depends on the curren locale and he current regex only works on some of them

Signed-off-by: Jose Luis Perez Diez <jluis@escomposlinux.org>