### PR TITLE
Fix warning - when github login is not defined

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHub.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub.pm
@@ -136,8 +136,9 @@ sub _get_repo_name {
 
     if ($repo !~ /.*\/.*/) {
         ($login, undef, undef) = $self->_get_credentials(1);
-
-        $repo = "$login/$repo";
+        if (defined $login) {
+            $repo = "$login/$repo";
+        }
     }
 
     return $repo;


### PR DESCRIPTION
Hi,

Please review the PR as it address the non-serious warning below:

Use of uninitialized value $login in concatenation (.) or string at /usr/local/share/perl/5.18.2/Dist/Zilla/Plugin/GitHub.pm line 140.

ManyThanks.
Best Regards,
Mohammad S Anwar