### PR TITLE
Enable optional auth for Meta requests

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHub.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub.pm
@@ -59,7 +59,7 @@ bundle|Dist::Zilla::PluginBundle::GitHub>.
 =cut
 
 sub _get_credentials {
-    my ($self, $nopass) = @_;
+    my $self = shift;
 
     my ($login, $pass, $token, $otp);
 
@@ -81,34 +81,32 @@ sub _get_credentials {
         return;
     }
 
-    if (!$nopass) {
-        if (%identity) {
-            $token = $identity{token};
-            $pass  = $identity{password};
-        } else {
-            $token = `git config github.token`;    chomp $token;
-            $pass  = `git config github.password`; chomp $pass;
+    if (%identity) {
+        $token = $identity{token};
+        $pass  = $identity{password};
+    } else {
+        $token = `git config github.token`;    chomp $token;
+        $pass  = `git config github.password`; chomp $pass;
 
-            # modern "tokens" can be used as passwords with basic auth, so...
-            # see https://help.github.com/articles/creating-an-access-token-for-command-line-use
-            $pass ||= $token if $token;
-        }
+        # modern "tokens" can be used as passwords with basic auth, so...
+        # see https://help.github.com/articles/creating-an-access-token-for-command-line-use
+        $pass ||= $token if $token;
+    }
 
-        $self->log("Err: Login with GitHub token is deprecated")
-            if $token && !$pass;
+    $self->log("Err: Login with GitHub token is deprecated")
+        if $token && !$pass;
 
-        if (!$pass) {
-            $pass = $self->zilla->chrome->prompt_str(
-                "GitHub password for '$login'", { noecho => 1 },
-            );
-        }
+    if (!$pass) {
+        $pass = $self->zilla->chrome->prompt_str(
+            "GitHub password for '$login'", { noecho => 1 },
+        );
+    }
 
-        if ($self->prompt_2fa) {
-            $otp = $self->zilla->chrome->prompt_str(
-                "GitHub two-factor authentication code for '$login'",
-                { noecho => 1 },
-            );
-        }
+    if ($self->prompt_2fa) {
+        $otp = $self->zilla->chrome->prompt_str(
+            "GitHub two-factor authentication code for '$login'",
+            { noecho => 1 },
+        );
     }
 
     return ($login, $pass, $otp);

--- a/lib/Dist/Zilla/Plugin/GitHub/Create.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub/Create.pm
@@ -111,7 +111,7 @@ sub after_mint {
         $repo_name = $self->zilla->name;
     }
 
-    my ($login, $pass, $otp)  = $self->_get_credentials(0);
+    my ($login, $pass, $otp)  = $self->_get_credentials;
 
     my $http = HTTP::Tiny->new;
 

--- a/lib/Dist/Zilla/Plugin/GitHub/Create.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub/Create.pm
@@ -111,8 +111,6 @@ sub after_mint {
         $repo_name = $self->zilla->name;
     }
 
-    my ($login, $pass, $otp)  = $self->_get_credentials;
-
     my $http = HTTP::Tiny->new;
 
     $self->log([ "Creating new GitHub repository '%s'", $repo_name ]);
@@ -139,23 +137,11 @@ sub after_mint {
     $url .= $self->org ? '/orgs/' . $self->org . '/' : '/user/';
     $url .= 'repos';
 
-    if ($pass) {
-        require MIME::Base64;
-
-        my $basic = MIME::Base64::encode_base64("$login:$pass", '');
-        $headers->{authorization} = "Basic $basic";
-    }
-
-    if ($self->prompt_2fa) {
-        $headers->{'X-GitHub-OTP'} = $otp;
-        $self->log([ "Using two-factor authentication" ]);
-    }
-
     $content = encode_json($params);
 
     my $response = $http->request('POST', $url, {
         content => $content,
-        headers => $headers
+        headers => $self->_auth_headers,
     });
 
     my $repo = $self->_check_response($response);

--- a/lib/Dist/Zilla/Plugin/GitHub/Meta.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub/Meta.pm
@@ -36,6 +36,12 @@ has fork => (
     default => 1
 );
 
+has require_auth => (
+    is      => 'ro',
+    isa     => 'Bool',
+    default => 0
+);
+
 =head1 SYNOPSIS
 
 Configure git with your GitHub login name:
@@ -124,7 +130,7 @@ sub metadata {
     $self->log("Getting GitHub repository info");
 
     my $url      = $self->api."/repos/$repo_name";
-    my $response = $http->request('GET', $url);
+    my $response = $http->request('GET', $url, $self->require_auth ? {headers => $self->_auth_headers} : ());
 
     my $repo = $self->_check_response($response);
     $offline = 1 if not $repo;
@@ -229,6 +235,20 @@ be activated (see the GitHub repository's C<Admin> panel).
 If the repository is a GitHub fork of another repository this option will make
 all the information be taken from the original repository instead of the forked
 one, if it's set to true (default).
+
+=item C<require_auth>
+
+If this is true, then the API request will be sent with Authorization
+headers. This is useful if you are behind some sort of proxy that is
+triggering the GitHub rate limiting.
+
+=item C<prompt_2fa>
+
+Prompt for GitHub two-factor authentication code if this option is set to true
+(default is false). If this option is set to false but GitHub requires 2fa for
+the login, it'll be automatically enabled.
+
+This is only relevant if C<require_auth> is true.
 
 =back
 

--- a/lib/Dist/Zilla/Plugin/GitHub/Update.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub/Update.pm
@@ -88,7 +88,7 @@ sub after_release {
     my ($opts)    = @_;
     my $dist_name = $self->zilla->name;
 
-    my ($login, $pass, $otp)  = $self->_get_credentials(0);
+    my ($login, $pass, $otp)  = $self->_get_credentials;
     return if (!$login);
 
     my $repo_name = $self->_get_repo_name($login);

--- a/t/01-update.t
+++ b/t/01-update.t
@@ -14,7 +14,7 @@ use Test::Deep::JSON;
     use Dist::Zilla::Plugin::GitHub;
     package Dist::Zilla::Plugin::GitHub;
     no warnings 'redefine';
-    sub _get_credentials { 'bob' }
+    sub _build_credentials { return {login => 'bob', pass => q{}, otp => q{}} }
     sub _get_repo_name { 'bob/My-Stuff' }
 }
 
@@ -44,7 +44,7 @@ my @tests = (
         ],
         expected_request => [
             PATCH => 'https://api.github.com/repos/bob/My-Stuff' => {
-                headers => undef,
+                headers => {},
                 content => json({
                     name => 'My-Stuff',
                     description => 'Sample DZ Dist',


### PR DESCRIPTION
I did some hand testing by hacking in some debugging output to HTTP::Tiny and I confirmed that the relevant headers were sent (or not) depending on the `require_auth` option.