### PR TITLE
Fix GH issue #55, infinite loop when using 2FA

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,9 +2,11 @@ Revision history for Dist-Zilla-Plugin-GitHub
 
 {{$NEXT}}
 
+  - Fix infinite loop when using 2FA (Joelle Maslak, #55)
+
 0.46      2018-08-05 01:19:21Z
 
-  - Fix error in calculating github credentials (J.Maslak, #52)
+  - Fix error in calculating github credentials (Joelle Maslak, #52)
   - the 'cpan' option in [GitHub::Update] is now deprecated, and will now
     behave as if the 'metacpan' option was set instead.
 

--- a/t/01-update.t
+++ b/t/01-update.t
@@ -14,7 +14,7 @@ use Test::Deep::JSON;
     use Dist::Zilla::Plugin::GitHub;
     package Dist::Zilla::Plugin::GitHub;
     no warnings 'redefine';
-    sub _build_credentials { return {login => 'bob', pass => q{}, otp => q{}} }
+    sub _build_credentials { return {login => 'bob', pass => q{} } }
     sub _get_repo_name { 'bob/My-Stuff' }
 }
 


### PR DESCRIPTION
I believe this fixes #55 .  I didn't write tests for it, but I have manually tested the fix against a GitHub account using 2FA.

This moves the OTP prompting code out of the builder method, instead asking the user when necessary for their 2FA code.