### PR TITLE
Fail if GitHub API request returns 404

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Dist-Zilla-Plugin-GitHub
 
 {{$NEXT}}
 
+  - Fail if repository URL is incorrect (indicated by GitHub returning HTTP 404
+    from API requests). The new option `continue_if_repo_not_found' can be set
+    to continue anyway.
+
 0.47      2018-09-16 22:43:24Z
 
   - Fix infinite loop when using 2FA (Joelle Maslak, #55)

--- a/lib/Dist/Zilla/Plugin/GitHub/Meta.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub/Meta.pm
@@ -221,20 +221,20 @@ the GitHub repository's info if this option is set to true (default).
 =item C<wiki>
 
 The META homepage field will be set to the URL of the wiki of the GitHub
-repository, if this option is set to true (default is false) and if the GitHub
+repository if this option is set to true (default is false) and if the GitHub
 Wiki happens to be activated (see the GitHub repository's C<Admin> panel).
 
 =item C<bugs>
 
-The META bugtracker web field will be set to the issue's page of the repository
-on GitHub, if this options is set to true (default) and if the GitHub Issues happen to
-be activated (see the GitHub repository's C<Admin> panel).
+The META bugtracker web field will be set to the issues page of the repository
+on GitHub if this option is set to true (default) and if GitHub Issues happens
+to be activated on the repository (see the GitHub repository's C<Admin> panel).
 
 =item C<fork>
 
 If the repository is a GitHub fork of another repository this option will make
 all the information be taken from the original repository instead of the forked
-one, if it's set to true (default).
+one if this is set to true (default).
 
 =item C<require_auth>
 

--- a/t/01-metadata.t
+++ b/t/01-metadata.t
@@ -1,0 +1,71 @@
+use strict;
+use warnings;
+
+use Dist::Zilla::Plugin::GitHub::Meta ();
+use HTTP::Tiny ();
+use Path::Tiny qw( path );
+use Test::DZil qw( Builder simple_ini );
+use Test::Fatal qw( exception );
+use Test::More 0.96;
+
+my @tests = (
+    {
+        name      => 'fail because repo is not found',
+        continue  => 0,
+        exception => 1,
+    },
+    {
+        name      => 'succeed even when repo is not found',
+        continue  => 1,
+        exception => 0,
+    },
+);
+
+for my $test (@tests) {
+    subtest $test->{name}, sub {
+        my $tzil = Builder->from_config(
+            { dist_root => 'does-not-exist' },
+            {
+                add_files => {
+                    path(qw(source dist.ini)) => simple_ini(
+                        [ FakeRelease => ],
+                        [
+                            'GitHub::Meta' => {
+                                continue_if_repo_not_found => $test->{continue},
+                            },
+                        ],
+                    ),
+                },
+            },
+        );
+
+        no warnings 'redefine';
+        *HTTP::Tiny::request = sub {
+            my ($self, $method, $url) = @_;
+            +{
+                content => '{"message":":-)"}',
+                status  => '404',
+                success => 0,
+                url     => $url,
+            };
+        };
+        *Dist::Zilla::Plugin::GitHub::Meta::_get_repo_name = sub { 'sdf' };
+
+        if ($test->{exception}) {
+            like(
+                exception { $tzil->release },
+                qr{\Qincorrect repository URL (HTTP 404 from https://api.github.com/repos/sdf},
+                'exception when repository URL detected incorrectly',
+            );
+            return;
+        }
+
+        is(
+            exception { $tzil->release },
+            undef,
+            'no exception when repository URL detected incorrectly',
+        );
+    };
+}
+
+done_testing;


### PR DESCRIPTION
This is as discussed in #56. Note it changes the default behaviour to fail if we get a 404 when making API requests. Personally I don't know why you'd want to continue if this happens at all so I thought changing the default behaviour would be okay, but we could switch this around if you think it would be common.