### PR TITLE
Require your GitHub username be available

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,10 @@ Revision history for Dist-Zilla-Plugin-GitHub
 
 {{$NEXT}}
 
+  - Require your GitHub username to be available (in Git's config or
+    otherwise). Previously this plugin would log this and halfway succeed in
+    some of its actions. This makes us more strictly check our preconditions.
+
 0.47      2018-09-16 22:43:24Z
 
   - Fix infinite loop when using 2FA (Joelle Maslak, #55)

--- a/lib/Dist/Zilla/Plugin/GitHub.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub.pm
@@ -37,8 +37,7 @@ has prompt_2fa => (
 
 has _login => (
     is      => 'ro',
-    isa     => 'Maybe[Str]',
-    lazy    => 1,
+    isa     => 'Str',
     builder => '_build_login',
 );
 
@@ -87,7 +86,7 @@ sub _build_login {
     if (%identity) {
         $login = $identity{login};
     } else {
-        $login = `git config github.user`;  chomp $login;
+        $login = _get_git_github_user();
     }
 
     if (!$login) {
@@ -95,10 +94,15 @@ sub _build_login {
             "Err: missing value 'user' in ~/.github" :
             "Err: Missing value 'github.user' in git config";
 
-        $self->log($error);
-        return undef;
+        die $error;
     }
 
+    return $login;
+}
+
+sub _get_git_github_user {
+    my $login = `git config github.user`;
+    chomp $login;
     return $login;
 }
 

--- a/lib/Dist/Zilla/Plugin/GitHub.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub.pm
@@ -178,7 +178,7 @@ sub _auth_headers {
 }
 
 sub _get_repo_name {
-    my ($self, $login) = @_;
+    my ($self) = @_;
 
     my $repo;
     my $git = Git::Wrapper->new('./');
@@ -198,7 +198,7 @@ sub _get_repo_name {
     $repo = $self->zilla->name unless $repo;
 
     if ($repo !~ /.*\/.*/) {
-        $login = $self->_login;
+        my $login = $self->_login;
         if (defined $login) {
             $repo = "$login/$repo";
         }

--- a/lib/Dist/Zilla/Plugin/GitHub/Update.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub/Update.pm
@@ -99,7 +99,7 @@ sub after_release {
 
     return if (!$self->_has_credentials);
 
-    my $repo_name = $self->_get_repo_name($self->_credentials->{login});
+    my $repo_name = $self->_get_repo_name;
     if (not $repo_name) {
         $self->log('cannot update GitHub repository info');
         return;

--- a/t/01-github.t
+++ b/t/01-github.t
@@ -1,0 +1,44 @@
+use strict;
+use warnings;
+
+use Dist::Zilla::Plugin::GitHub ();
+use Test::Fatal qw( exception );
+use Test::More 0.96;
+
+my @tests = (
+    {
+        name    => 'have github.user',
+        user    => 'tester',
+        success => 1,
+    },
+    {
+        name    => 'do not have github.user',
+        user    => '',
+        success => 0,
+    }
+);
+
+for my $test (@tests) {
+    subtest $test->{name}, sub {
+        no warnings 'redefine';
+        *Dist::Zilla::Plugin::GitHub::_get_git_github_user = sub {
+            $test->{user};
+        };
+
+        if ($test->{success}) {
+            is(
+                exception { Dist::Zilla::Plugin::GitHub->new },
+                undef,
+                'no exception without github.user',
+            );
+            return;
+        }
+        like(
+            exception { Dist::Zilla::Plugin::GitHub->new },
+            qr{\QMissing value 'github.user' in git config},
+            'exception when no github.user set',
+        );
+    };
+}
+
+done_testing;


### PR DESCRIPTION
This is to address #50.

I realize it is a bit strict. But I think it makes sense when releasing to be strict about information being available.