### PR TITLE
Fix minor typo in ATTRIBUTES docs

### DIFF
--- a/lib/Dist/Zilla/Plugin/GitHub/Meta.pm
+++ b/lib/Dist/Zilla/Plugin/GitHub/Meta.pm
@@ -227,7 +227,7 @@ Wiki happens to be activated (see the GitHub repository's C<Admin> panel).
 =item C<bugs>
 
 The META bugtracker web field will be set to the issue's page of the repository
-on GitHub, if this options is set to true (default) and if the GitHub Issues happen to
+on GitHub, if this option is set to true (default) and if the GitHub Issues happen to
 be activated (see the GitHub repository's C<Admin> panel).
 
 =item C<fork>


### PR DESCRIPTION
While reading through the ATTRIBUTE docs I noticed this minor typo and thought I'd submit a patch for it.  Hope it helps :-)